### PR TITLE
Compile fixes for PHP 5.5 & VC11

### DIFF
--- a/ext/gtk+/config.w32
+++ b/ext/gtk+/config.w32
@@ -27,12 +27,12 @@ if (CHECK_HEADER("main/php.h") && CHECK_LIB(PHP_LIB) &&
 		/* Create the file if it doesn't exist */
 		var temp = FSO.OpenTextFile("win32\\temp.bat", 8);
 		/* generate source and header files for exported PHP-GTK functions */
-		temp.WriteLine("/* usage: php generator.php [-l logfile] [-o overridesfile] [-p prefix] [-c functionclass ] [-r typesfile] [-f savefile] [-v gtklibversion] defsfile */");
+		temp.WriteLine("/* usage: php gtkgenerator.php [-l logfile] [-o overridesfile] [-p prefix] [-c functionclass ] [-r typesfile] [-f savefile] [-v gtklibversion] defsfile */");
 		temp.WriteLine("mkdir win32\\logs");
-		temp.WriteLine("php -q generator\\generator.php -l win32\\logs\\config_atk.log -o ext\\gtk+\\atk.overrides -p atk ext\\gtk+\\atk.defs -v " + PHP_GTK_LIBVERSION + " -f ext\\gtk+\\gen_atk.c >> sources.temp");
-		temp.WriteLine("php -q generator\\generator.php -l win32\\logs\\config_pango.log -o ext\\gtk+\\pango.overrides -p pango ext\\gtk+\\pango.defs -v " + PHP_GTK_LIBVERSION + " -f ext\\gtk+\\gen_pango.c >> sources.temp");
-		temp.WriteLine("php -q generator\\generator.php -l win32\\logs\\config_gdk.log -o ext\\gtk+\\gdk.overrides -p gdk -r ext\\gtk+\\atk-types.defs -v " + PHP_GTK_LIBVERSION + " -r ext\\gtk+\\pango-types.defs ext\\gtk+\\gdk.defs -f ext\\gtk+\\gen_gdk.c >> sources.temp");
-		temp.WriteLine("php -q generator\\generator.php -l win32\\logs\\config_gtk.log -o ext\\gtk+\\gtk.overrides -p gtk -r ext\\gtk+\\atk-types.defs -v " + PHP_GTK_LIBVERSION + " -r ext\\gtk+\\pango-types.defs -r ext\\gtk+\\gdk-types.defs ext\\gtk+\\gtk.defs -f ext\\gtk+\\gen_gtk.c >> sources.temp");
+		temp.WriteLine("php -q generator\\gtkgenerator.php -l win32\\logs\\config_atk.log -o ext\\gtk+\\atk.overrides -p atk ext\\gtk+\\atk.defs -v " + PHP_GTK_LIBVERSION + " -f ext\\gtk+\\gen_atk.c >> sources.temp");
+		temp.WriteLine("php -q generator\\gtkgenerator.php -l win32\\logs\\config_pango.log -o ext\\gtk+\\pango.overrides -p pango ext\\gtk+\\pango.defs -v " + PHP_GTK_LIBVERSION + " -f ext\\gtk+\\gen_pango.c >> sources.temp");
+		temp.WriteLine("php -q generator\\gtkgenerator.php -l win32\\logs\\config_gdk.log -o ext\\gtk+\\gdk.overrides -p gdk -r ext\\gtk+\\atk-types.defs -v " + PHP_GTK_LIBVERSION + " -r ext\\gtk+\\pango-types.defs ext\\gtk+\\gdk.defs -f ext\\gtk+\\gen_gdk.c >> sources.temp");
+		temp.WriteLine("php -q generator\\gtkgenerator.php -l win32\\logs\\config_gtk.log -o ext\\gtk+\\gtk.overrides -p gtk -r ext\\gtk+\\atk-types.defs -v " + PHP_GTK_LIBVERSION + " -r ext\\gtk+\\pango-types.defs -r ext\\gtk+\\gdk-types.defs ext\\gtk+\\gtk.defs -f ext\\gtk+\\gen_gtk.c >> sources.temp");
 		temp.WriteLine('grep -h "^PHP_GTK_EXPORT_CE" ext\\gtk+\\gen_atk.c | sed -e "s/^/PHP_GTK_API extern /" > ext\\gtk+\\gen_atk.h');
 		temp.WriteLine('grep -h "^PHP_GTK_EXPORT_CE" ext\\gtk+\\gen_pango.c | sed -e "s/^/PHP_GTK_API extern /" > ext\\gtk+\\gen_pango.h');
 		temp.WriteLine('grep -h "^PHP_GTK_EXPORT_CE" ext\\gtk+\\gen_gdk.c | sed -e "s/^/PHP_GTK_API extern /" > ext\\gtk+\\gen_gdk.h');

--- a/ext/libglade/config.w32
+++ b/ext/libglade/config.w32
@@ -9,7 +9,7 @@ if (PHP_GTK_LIBGLADE != "no" || PHP_GTK_ALL != "no") {
 
 			var temp = FSO.OpenTextFile("win32\\temp.bat", 8);
 
-			temp.WriteLine("php -q generator\\generator.php -l win32\\logs\\config_glade.log -o ext\\libglade\\libglade.overrides -p glade -r ext\\gtk+\\gtk.defs ext\\libglade\\libglade.defs -f ext\\libglade\\gen_libglade.c");
+			temp.WriteLine("php -q generator\\gtkgenerator.php -l win32\\logs\\config_glade.log -o ext\\libglade\\libglade.overrides -p glade -r ext\\gtk+\\gtk.defs ext\\libglade\\libglade.defs -f ext\\libglade\\gen_libglade.c");
 
 			temp.WriteLine('grep -h "^PHP_GTK_EXPORT_CE" ext\\libglade\\gen_libglade.c | sed -e "s/^/PHP_GTK_API extern /" > ext\\libglade\\gen_libglade.h');
 

--- a/ext/libsexy/config.w32
+++ b/ext/libsexy/config.w32
@@ -6,7 +6,7 @@ if (PHP_GTK_LIBSEXY != "no" || PHP_GTK_ALL != "no")
 		if (FSO.FileExists("win32\\temp.bat"))
 		{ 
 			var temp = FSO.OpenTextFile("win32\\temp.bat", 8);
-			temp.WriteLine("php -q generator\\generator.php -l win32\\logs\\config_libsexy.log -o ext\\libsexy\\sexy.overrides -p sexy -r ext\\gtk+\\gtk.defs ext\\libsexy\\sexy.defs > ext\\libsexy\\gen_libsexy.c");
+			temp.WriteLine("php -q generator\\gtkgenerator.php -l win32\\logs\\config_libsexy.log -o ext\\libsexy\\sexy.overrides -p sexy -r ext\\gtk+\\gtk.defs ext\\libsexy\\sexy.defs > ext\\libsexy\\gen_libsexy.c");
 			temp.WriteLine('grep -h "^PHP_GTK_EXPORT_CE" ext\\libsexy\\gen_libsexy.c | sed -e "s/^/PHP_GTK_API extern /" > ext\\libsexy\\gen_libsexy.h');
  			temp.Close(); 		
 		}

--- a/ext/sourceview/config.w32
+++ b/ext/sourceview/config.w32
@@ -7,7 +7,7 @@ if (PHP_GTK_SOURCEVIEW != "no" || PHP_GTK_ALL != "no") {
 		if (FSO.FileExists("win32\\temp.bat")) {
 
 			var temp = FSO.OpenTextFile("win32\\temp.bat", 8);
-			temp.WriteLine("php -q generator\\generator.php -l win32\\logs\\config_sourceview.log -o ext\\sourceview\\sourceview.overrides -p gtksourceview -r ext\\gtk+\\gtk.defs ext\\sourceview\\sourceview.defs > ext\\sourceview\\gen_sourceview.c");
+			temp.WriteLine("php -q generator\\gtkgenerator.php -l win32\\logs\\config_sourceview.log -o ext\\sourceview\\sourceview.overrides -p gtksourceview -r ext\\gtk+\\gtk.defs ext\\sourceview\\sourceview.defs > ext\\sourceview\\gen_sourceview.c");
                   temp.WriteLine('grep -h "^PHP_GTK_EXPORT_CE" ext\\sourceview\\gen_sourceview.c | sed -e "s/^/PHP_GTK_API extern /" > ext\\sourceview\\gen_sourceview.h');		
 			temp.Close();
 		}

--- a/generator/gtkgenerator.php
+++ b/generator/gtkgenerator.php
@@ -48,7 +48,7 @@ require dirname(__FILE__) . "/templates.php";
 require dirname(__FILE__) . "/array_printf.php";
 require dirname(__FILE__) . "/lineoutput.php";
 
-class Generator {
+class gtkGenerator {
     var $parser             = null;
     var $overrides          = null;
     var $prefix             = null;
@@ -75,7 +75,7 @@ class Generator {
                                     'unset_dimension', 'count_elements');
     var $cover              = array();
 
-    function Generator(&$parser, &$overrides, $prefix, $function_class)
+    function gtkGenerator(&$parser, &$overrides, $prefix, $function_class)
     {
         $this->parser    = &$parser;
         $this->overrides = &$overrides;
@@ -1135,7 +1135,7 @@ class Generator {
             }
 
             if ($this->overrides->has_extra_arginfo($class_name, $method_name)) {
-                $reflection_funcname = Generator::getReflectionFuncName($method, $class, $det_method_name);
+                $reflection_funcname = gtkGenerator::getReflectionFuncName($method, $class, $det_method_name);
                 $reflection_func = str_repeat(' ', $len) . $reflection_funcname;
 
                 $arginfo = str_replace('ARGINFO_NAME', $reflection_funcname, $this->overrides->get_extra_arginfo($class_name, $method_name));
@@ -1150,7 +1150,7 @@ class Generator {
             $reflection_func = str_repeat(' ', $len) . 'NULL';
             $arginfo = null;
         } else {
-            $reflection_funcname = Generator::getReflectionFuncName($method, $class);
+            $reflection_funcname = gtkGenerator::getReflectionFuncName($method, $class);
             $reflection_func = str_repeat(' ', $len) . $reflection_funcname;
 
             $param_count = 0;
@@ -1164,7 +1164,7 @@ class Generator {
                 }
 
                 $paramtype = str_replace('const-', '', str_replace('*', '', $paraminfo[0]));
-                if (Generator::is_php_type($paramtype)) {
+                if (gtkGenerator::is_php_type($paramtype)) {
                     $argparams .= sprintf(Templates::reflection_arg, $paraminfo[1]);
                 } else {
                     $argparams .= sprintf(Templates::reflection_objarg, $paraminfo[1], $paramtype);
@@ -1493,7 +1493,7 @@ function fatal_error($message) {
     $fh = fopen("php://stderr", "w");
         fwrite($fh,"\n\n\n\n
 ========================================================================    
-    There was a Serious error with the PHP-GTK generator script
+    There was a Serious error with the PHP-GTK gtkGenerator script
 ========================================================================    
     $message
 ========================================================================    
@@ -1512,7 +1512,7 @@ $old_error_reporting = error_reporting(E_ALL);
 
 if (!isset($_SERVER['argv'])) 
     fatal_error("
-        Could not read command line arguments for generator.php 
+        Could not read command line arguments for gtkgenerator.php 
         Please ensure that this option is set in your php.ini
         register_argc_argv = On     
     ");
@@ -1527,7 +1527,7 @@ if (isset($_SERVER['argc']) &&
  
 $result = Console_Getopt::getopt($argv, 'l:o:p:c:r:f:v:');
 if (!$result || count($result[1]) < 2)
-    die("usage: php generator.php [-l logfile] [-o overridesfile] [-p prefix] [-c functionclass ] [-r typesfile] [-f savefile] [-v gtklibversion] defsfile\n");
+    die("usage: php gtkgenerator.php [-l logfile] [-o overridesfile] [-p prefix] [-c functionclass ] [-r typesfile] [-f savefile] [-v gtklibversion] defsfile\n");
 
 list($opts, $argv) = $result;
 
@@ -1564,7 +1564,7 @@ if (file_exists(dirname($argv[1]) . '/arg_types.php')) {
 
 $overrides = new Overrides($overrides, $gtkversion);
 $parser = new Defs_Parser($argv[1], $gtkversion);
-$generator = new Generator($parser, $overrides, $prefix, $function_class);
+$generator = new gtkGenerator($parser, $overrides, $prefix, $function_class);
 $generator->set_logfile($logfile);
 foreach ($register_defs as $defs) {
     $type_parser = new Defs_Parser($defs, $gtkversion);

--- a/main/php_gtk.h
+++ b/main/php_gtk.h
@@ -77,6 +77,15 @@
 # define PHPGTK_PROPERTY_END , const zend_literal *key TSRMLS_DC
 #endif
 
+/* get_property_ptr_ptr had type added in 5.5*/
+#if PHP_VERSION_ID >= 50500
+# define ZEND_GET_PPTR_TYPE_DC , int type
+# define ZEND_GET_PPTR_TYPE_CC , type
+#else
+# define ZEND_GET_PPTR_TYPE_DC
+# define ZEND_GET_PPTR_TYPE_CC
+#endif
+
 #if HAVE_PHP_GTK
 
 #include "zend_objects_API.h"
@@ -308,7 +317,7 @@ int php_gtk_startup_extensions(php_gtk_ext_entry **ext, int ext_count, int modul
 
 zval *phpg_read_property(zval *object, zval *member, int type PHPGTK_PROPERTY_END);
 void phpg_write_property(zval *object, zval *member, zval *value PHPGTK_PROPERTY_END);
-zval **phpg_get_property_ptr_ptr(zval *object, zval *member PHPGTK_PROPERTY_END);
+zval **phpg_get_property_ptr_ptr(zval *object, zval *member ZEND_GET_PPTR_TYPE_DC PHPGTK_PROPERTY_END);
 HashTable* phpg_get_properties(zval *object TSRMLS_DC);
 PHP_GTK_API void phpg_get_properties_helper(zval *object, HashTable *ht TSRMLS_DC, ...);
 

--- a/main/phpg_support.c
+++ b/main/phpg_support.c
@@ -120,7 +120,7 @@ void phpg_write_property(zval *object, zval *member, zval *value PHPGTK_PROPERTY
 /* }}} */
 
 /* {{{ phpg_get_property_ptr_ptr() */
-zval **phpg_get_property_ptr_ptr(zval *object, zval *member PHPGTK_PROPERTY_END)
+zval **phpg_get_property_ptr_ptr(zval *object, zval *member ZEND_GET_PPTR_TYPE_DC PHPGTK_PROPERTY_END)
 {
     phpg_head_t *poh = NULL;
     zval tmp_member;
@@ -155,7 +155,7 @@ zval **phpg_get_property_ptr_ptr(zval *object, zval *member PHPGTK_PROPERTY_END)
 	#if PHP_VERSION_ID < 50399
 		result = zend_get_std_object_handlers()->get_property_ptr_ptr(object, member TSRMLS_CC);
 	#else
-		result = zend_get_std_object_handlers()->get_property_ptr_ptr(object, member, NULL TSRMLS_CC);
+		result = zend_get_std_object_handlers()->get_property_ptr_ptr(object, member ZEND_GET_PPTR_TYPE_CC, NULL TSRMLS_CC);
 	#endif
     }
 

--- a/win32/config.w32.in
+++ b/win32/config.w32.in
@@ -10,6 +10,7 @@ MSVCVERS[1310] = 'MSVC7.1 (Visual C++ 2003)';
 MSVCVERS[1400] = 'MSVC8 (Visual C++ 2005)';
 MSVCVERS[1500] = 'MSVC9 (Visual C++ 2008)';
 MSVCVERS[1600] = 'MSVC10 (Visual C++ 2010)';
+MSVCVERS[1700] = 'MSVC11 (Visual C++ 2012)';
 
 STDOUT.WriteBlankLines(1);
 


### PR DESCRIPTION
Renamed generator.php and related functions/classes to get around keyword issue in > 5.5. Does not break backwards compatibility.
